### PR TITLE
Implementing navigation the Gatsby way

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,24 @@ module.exports = {
     title: `Gatsby Default Starter`,
     description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
     author: `@gatsbyjs`,
+    menuLinks:[
+      {
+         name:'home',
+         link:'/'
+      },
+      {
+         name:'speakers',
+         link:'/page-2'
+      },
+      {
+         name:'events',
+         link:'/page-2'
+      },
+      {
+         name:'sponsors',
+         link:'/sponsorships'
+      },
+    ]
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import React from "react"
 import Navigation from './navigation'
 
-const Header = ({ siteTitle }) => (
+const Header = ({ siteTitle, menuLinks }) => (
   <header
     style={{
       background: `rebeccapurple`,
@@ -29,7 +29,7 @@ const Header = ({ siteTitle }) => (
         </Link>
       </h1>
     </div>
-    <Navigation />
+    <Navigation menuLinks={menuLinks} />
   </header>
 )
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -19,6 +19,10 @@ const Layout = ({ children }) => {
       site {
         siteMetadata {
           title
+            menuLinks {
+              name
+              link
+            }
         }
       }
     }
@@ -26,7 +30,7 @@ const Layout = ({ children }) => {
 
   return (
     <>
-      <Header siteTitle={data.site.siteMetadata.title} />
+      <Header menuLinks={data.site.siteMetadata.menuLinks} siteTitle={data.site.siteMetadata.title} />
       <div
         style={{
           margin: `0 auto`,

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,5 +1,28 @@
 import React from "react"
+import { Link } from "gatsby"
 
-export default function() {
-  ;<h1>Navigation</h1>
+const Navigation = ({ menuLinks }) => {
+  return (
+    <div>
+      <nav>
+        <ul style={{ display: "flex", flex: 1 }}>
+          {menuLinks.map(link => (
+            <li
+              key={link.name}
+              style={{
+                listStyleType: `none`,
+                padding: `1rem`,
+              }}
+            >
+              <Link style={{ color: `white` }} to={link.link}>
+                {link.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+  )
 }
+
+export default Navigation


### PR DESCRIPTION
This builds out the _unstyled_ `<Naviagion />` component based on the [Gadsby Reference Guide](https://www.gatsbyjs.org/docs/centralizing-your-sites-navigation/)

Addresses: [sem-js@issues#12](https://github.com/sem-js/sem-js/issues/12)
<img width="500" alt="Navigation" src="https://user-images.githubusercontent.com/181873/67136252-beae0a00-f1f1-11e9-800d-ac9477485cc2.png">

## Notes:
 - This addresses current [`master@793dc9f378`](https://github.com/sem-js/sem-js/tree/793dc9f378613a86ce6a793a84512a33d62197ff) is throwing the following error on `npm start`
```
sem-js/src/components/navigation.js
  4:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

✖ 1 problem (1 error, 0 warnings)
```