### PR TITLE
Accessible emoji fix

### DIFF
--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -1,0 +1,14 @@
+import React from "react"
+
+const Emoji = props => (
+  <span
+    className="emoji"
+    role="img"
+    aria-label={props.label ? props.label : ""}
+    aria-hidden={props.label ? "false" : "true"}
+  >
+    {props.symbol}
+  </span>
+)
+
+export default Emoji

--- a/src/pages/sponsorships.js
+++ b/src/pages/sponsorships.js
@@ -3,6 +3,7 @@ import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
+import Emoji from "../components/emoji"
 
 const SecondPage = () => (
   <Layout>
@@ -28,7 +29,7 @@ const SecondPage = () => (
       <li>2-3 minutes to pitch your company and its opportunities</li>
       <li>Priority listings for job inquiries through <a href="mailto:jobs@semjs.org">jobs@semjs.org</a></li>
     </ul>
-    <h3>Interested? Fill out our form below 👇</h3>
+    <h3>Interested? Fill out our form below <Emoji symbol="👇" label="Pointing Down"/></h3>
     <div>
       .... FORM TO GO HERE ....
       <br />


### PR DESCRIPTION
This addresses current [`master@793dc9f378`](https://github.com/sem-js/sem-js/tree/793dc9f378613a86ce6a793a84512a33d62197ff) build issue with bare emoji:

```
sem-js/src/pages/sponsorships.js
  31:5  warning  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby
jsx-a11y/accessible-emoji

✖ 1 problem (0 errors, 1 warning)
failed Building development bundle - 5.233s
```

<img width="1265" alt="eslint accessible emoji" src="https://user-images.githubusercontent.com/181873/67136215-2ca60180-f1f1-11e9-9d33-51428035c5d9.png">


/ht https://medium.com/@seanmcp/%EF%B8%8F-how-to-use-emojis-in-react-d23bbf608bf7